### PR TITLE
Image sizes not available for new entries

### DIFF
--- a/system/expressionengine/third_party/picture/ft.picture.php
+++ b/system/expressionengine/third_party/picture/ft.picture.php
@@ -88,7 +88,7 @@ class Picture_ft extends EE_Fieldtype {
 			}
 
 			$picture_image = '';
-			$picture_upload_dir = '';
+			$picture_upload_dir = $this->settings['picture_upload_dir'];
 			$picture_alignment = '';
 			$picture_size = '';
 			$picture_url = '';


### PR DESCRIPTION
Fixes bug where you were unable to pick from image sizes for the specified upload directory when adding a new entry.
